### PR TITLE
fixed built-in function TypeError and mathlog example

### DIFF
--- a/examples/mathlog.py
+++ b/examples/mathlog.py
@@ -1,0 +1,9 @@
+
+from math import log
+
+def print_log(n):
+    print log(n, 2)
+
+if __name__ == '__main__':
+    import clime
+    clime.main()


### PR DESCRIPTION
python examples/mathlog.py 
Traceback (most recent call last):
  File "examples/mathlog.py", line 9, in <module>
    clime.main()
  File "/Users/ben_wei/src/github/clime/clime.py", line 306, in main
    prog(sys.argv[1:])
  File "/Users/ben_wei/src/github/clime/clime.py", line 264, in **call**
    self.help()
  File "/Users/ben_wei/src/github/clime/clime.py", line 240, in help
    usages = self.get_cmds_usages()
  File "/Users/ben_wei/src/github/clime/clime.py", line 225, in get_cmds_usages
    return [ Command(func).get_usage() for func in self.funcs.values() ]
  File "/Users/ben_wei/src/github/clime/clime.py", line 54, in **init**
    spec = inspect.getargspec(func)
  File "/System/Library/Frameworks/Python.framework/Versions/2.7/lib/python2.7/inspect.py", line 813, in getargspec
    raise TypeError('{!r} is not a Python function'.format(func))
TypeError: <built-in function log> is not a Python function
