### PR TITLE
Add 'float' support for parsing Commands

### DIFF
--- a/clime/core.py
+++ b/clime/core.py
@@ -59,6 +59,7 @@ class Command(object):
         'n': int, 'num': int, 'number': int,
         'i': int, 'int': int, 'integer': int,
         's': str, 'str': str, 'string': str,
+        'f': float, 'float': float,
         'json': json,
         None: autotype
     }
@@ -66,6 +67,7 @@ class Command(object):
 
     The ``n``, ``num``, ``number``, ``i``, ``int`` and ``integer`` mean a `int`.
     The ``s``, ``str`` and ``string`` mean a `str`.
+    The ``f`` and ``float`` mean a `float`.
 
     It also supports to use ``json``. It converts the json from user to a Python
     type.


### PR DESCRIPTION
Since `clime.util.autotype` supports `float` type, so I add it to default command parser.
Enabling the following syntax:

`````` """
options:
    --ratio=<float> Blah blah blah
"""```
``````
