### PR TITLE
Fix error when clime.now is imported in a module without any callables

### DIFF
--- a/clime/core.py
+++ b/clime/core.py
@@ -632,7 +632,6 @@ class Program(object):
             usages.append(Command(cmd_func, cmd_name).build_usage(without_name))
 
         usages = []
-        cmd_func = None
 
         if cmd_name is None:
             # prepare all usages

--- a/clime/core.py
+++ b/clime/core.py
@@ -648,9 +648,13 @@ class Program(object):
 
         # print the usages
         iusages = iter(usages)
-        print('usage:', next(iusages))
-        for usage in iusages:
-            print('   or:', usage)
+        try:
+            print('usage:', next(iusages))
+        except StopIteration:   # Empty usages; print nothing.
+            pass
+        else:
+            for usage in iusages:
+                print('   or:', usage)
 
         # find the doc
 


### PR DESCRIPTION
To reproduce, run `import clime.now` in an empty module.

This patch eats the exception and outputs nothing if there's nothing to print.

I also removed the `cmd_func` local variable because it is not needed anywhere.