### PR TITLE
Add Makefile with Nose testing script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,18 @@
+.PHONY: clean docs test
+
+clean:
+	rm -fr build/
+	rm -fr dist/
+	rm -fr *.egg-info
+	find . -name '*.pyc' -exec rm -f {} +
+	find . -name '*.pyo' -exec rm -f {} +
+	find . -name '*~' -exec rm -f {} +
+	find . -name '__pycache__' -exec rm -fr {} +
+
+docs:
+	$(MAKE) -C docs clean
+	$(MAKE) -C docs html
+	open docs/_build/html/index.html
+
+test:
+	nosetests --with-sphinx


### PR DESCRIPTION
This is mostly for introducing the `nosetests --with-sphinx` command. I added some other pseudo-targets for convenience.

You’ll need to `pip install sphinx-nose` first to make the `--with-sphinx` flag work.
